### PR TITLE
docs: add contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing
+
+Thank you for your interest in improving EnderLink.
+
+## Setup
+
+1. Fork this repository and clone your fork.
+2. Install dependencies:
+   ```bash
+   yarn install
+   ```
+
+## Development Workflow
+
+1. Create a new branch for your change:
+   ```bash
+   git checkout -b your-branch-name
+   ```
+2. Make your changes.
+3. Run lint checks:
+   ```bash
+   npm run lint
+   ```
+4. Run tests if available:
+   ```bash
+   npm test
+   ```
+5. Commit your work:
+   ```bash
+   git commit -am "feat: your message"
+   ```
+6. Push the branch and open a pull request.
+
+We appreciate your contributions!
+


### PR DESCRIPTION
## Summary
- add contributing guide with basic workflow

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ENOENT no such file or directory .eslintrc)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e0177ba8832ea4dd86c6d9cfe5d4