### PR TITLE
chore: relax node engine requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.6",
   "author": "yadokari1130",
   "main": "dist/electron/main/main.js",
+  "packageManager": "yarn@1.22.22",
   "scripts": {
     "vite:dev": "vite",
     "vite:build": "vue-tsc --noEmit && vite build",
@@ -101,7 +102,7 @@
     "vue-tsc": "^0.34.7"
   },
   "engines": {
-    "node": "20.12.1"
+    "node": "^20.12.1"
   },
   "resolutions": {
     "@types/mime": "3.0.4"


### PR DESCRIPTION
## Summary
- allow Node 20 minor versions by relaxing engine constraint
- document yarn 1.22.22 as the package manager

## Testing
- `yarn install --frozen-lockfile` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `yarn lint` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e83e44cc832eaf9a69ed8b24b3dd