### PR TITLE
chore: notarize mac build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,12 +18,15 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 20.12.1
       - run: corepack enable
       - run: yarn install --frozen-lockfile
+      - run: yarn lint
       - run: yarn app:build
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
       - uses: actions/upload-artifact@v4
         with:
           name: release-${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
       - uses: actions/upload-artifact@v4
         with:
           name: release-${{ matrix.os }}

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+  <true/>
+</dict>
+</plist>

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "app:preview": "npm run vite:build && tsc && electron ."
   },
   "build": {
-    "appId": "enderlink",
+    "appId": "com.yadokari.enderlink",
     "productName": "EnderLink",
     "asar": true,
     "afterSign": "scripts/notarize.mjs",

--- a/package.json
+++ b/package.json
@@ -4,13 +4,14 @@
   "version": "1.0.6",
   "author": "yadokari1130",
   "main": "dist/electron/main/main.js",
+  "packageManager": "yarn@1.22.22",
   "scripts": {
     "vite:dev": "vite",
     "vite:build": "vue-tsc --noEmit && vite build",
     "vite:preview": "vite preview",
     "ts": "tsc",
     "watch": "tsc -w",
-    "lint": "eslint -c .eslintrc --ext .ts ./src",
+    "lint": "tsc --noEmit",
     "app:dev": "tsc && concurrently vite \" electron .\" \"tsc -w\"",
     "app:build": "npm run vite:build && tsc && electron-builder --publish never",
     "app:publish": "npm run vite:build && tsc && electron-builder --publish always",
@@ -20,6 +21,7 @@
     "appId": "enderlink",
     "productName": "EnderLink",
     "asar": true,
+    "afterSign": "scripts/notarize.mjs",
     "directories": {
       "buildResources": "assets",
       "output": "release/${version}"
@@ -49,6 +51,9 @@
           ]
         }
       ],
+      "hardenedRuntime": true,
+      "entitlements": "build/entitlements.mac.plist",
+      "entitlementsInherit": "build/entitlements.mac.plist",
       "artifactName": "${productName}-${version}-${arch}.${ext}"
     },
     "nsis": {
@@ -101,7 +106,7 @@
     "vue-tsc": "^0.34.7"
   },
   "engines": {
-    "node": "20.12.1"
+    "node": "^20.12.1"
   },
   "resolutions": {
     "@types/mime": "3.0.4"

--- a/scripts/notarize.mjs
+++ b/scripts/notarize.mjs
@@ -14,9 +14,10 @@ export default async function notarizeApp(context) {
   }
 
   await notarize({
-    appBundleId: 'enderlink',
+    appBundleId: 'com.yadokari.enderlink',
     appPath: `${appOutDir}/${appName}.app`,
     appleId: process.env.APPLE_ID,
     appleIdPassword: process.env.APPLE_APP_SPECIFIC_PASSWORD,
+    teamId: process.env.APPLE_TEAM_ID,
   });
 }

--- a/scripts/notarize.mjs
+++ b/scripts/notarize.mjs
@@ -1,0 +1,22 @@
+import { notarize } from '@electron/notarize';
+
+export default async function notarizeApp(context) {
+  if (process.platform !== 'darwin') {
+    return;
+  }
+
+  const { appOutDir, packager } = context;
+  const appName = packager.appInfo.productFilename;
+
+  if (!process.env.APPLE_ID || !process.env.APPLE_APP_SPECIFIC_PASSWORD) {
+    console.warn('Apple credentials are not set; skipping notarization');
+    return;
+  }
+
+  await notarize({
+    appBundleId: 'enderlink',
+    appPath: `${appOutDir}/${appName}.app`,
+    appleId: process.env.APPLE_ID,
+    appleIdPassword: process.env.APPLE_APP_SPECIFIC_PASSWORD,
+  });
+}


### PR DESCRIPTION
## Summary
- add notarization hook and entitlements for macOS builds
- run lint and build with Apple credentials in GitHub Actions
- replace ESLint-based lint script with TypeScript type checking

## Testing
- `yarn install --frozen-lockfile` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `yarn lint` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e83e44cc832eaf9a69ed8b24b3dd