### PR TITLE
feat(cli): add stop and status commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,21 @@
 さらに、取ったバックアップまで簡単に戻すことができます
 
 ## GUI上で設定可能
-サーバーの細かな設定をGUI上で変更可能です  
+サーバーの細かな設定をGUI上で変更可能です
 `server.properties`の内容や、サーバーアイコン、OP権限、ホワイトリスト、ワールド、プラグイン等を設定可能です
+
+## CLI版
+コマンドラインからサーバーの操作を行うためのCLIが同梱されています
+以下のように実行します
+
+```bash
+npx elder start <server>
+npx elder stop <server>
+npx elder status <server>
+```
+
+GitHubリポジトリとトークンは環境変数`GITHUB_REPOSITORY`,`GITHUB_TOKEN`を設定するか、
+`--repo`と`--token`オプションで指定してください
 
 <!-- omit in toc -->
 # 注意

--- a/bin/elder.js
+++ b/bin/elder.js
@@ -2,24 +2,46 @@
 const { Octokit } = require('@octokit/rest');
 
 function usage() {
-  console.log('Usage: elder start <serverName>');
+  console.log('Usage: elder <command> [options] <serverName>');
+  console.log('Commands:');
+  console.log('  start  <server>   Start the server');
+  console.log('  stop   <server>   Stop the server');
+  console.log('  status <server>   Show server status');
+  console.log('Options:');
+  console.log('  --repo  <owner/repo>   GitHub repository (defaults to $GITHUB_REPOSITORY)');
+  console.log('  --token <token>        GitHub token (defaults to $GITHUB_TOKEN)');
+}
+
+function getOption(args, name) {
+  const index = args.indexOf(name);
+  if (index !== -1 && args[index + 1]) return args[index + 1];
+  return null;
 }
 
 async function main() {
-  const [, , command, serverName] = process.argv;
+  const args = process.argv.slice(2);
+  const command = args[0];
+  const serverName = args[1];
+
   if (!command || command === '--help' || command === '-h') {
     usage();
     return;
   }
 
-  const repo = process.env.GITHUB_REPOSITORY;
-  const token = process.env.GITHUB_TOKEN;
+  const repo = getOption(args, '--repo') || process.env.GITHUB_REPOSITORY;
+  const token = getOption(args, '--token') || process.env.GITHUB_TOKEN;
   if (!repo) {
-    console.error('GITHUB_REPOSITORY environment variable is required');
+    console.error('GitHub repository is required (use --repo or set GITHUB_REPOSITORY)');
     process.exit(1);
   }
   if (!token) {
-    console.error('GITHUB_TOKEN environment variable is required');
+    console.error('GitHub token is required (use --token or set GITHUB_TOKEN)');
+    process.exit(1);
+  }
+
+  if (!serverName) {
+    console.error('Missing server name');
+    usage();
     process.exit(1);
   }
 
@@ -28,11 +50,6 @@ async function main() {
 
   switch (command) {
     case 'start':
-      if (!serverName) {
-        console.error('Missing server name');
-        usage();
-        process.exit(1);
-      }
       await octokit.repos.createDispatchEvent({
         owner,
         repo: repoName,
@@ -40,6 +57,29 @@ async function main() {
         client_payload: { server: serverName },
       });
       console.log(`Dispatch for server '${serverName}' sent`);
+      break;
+    case 'stop':
+      await octokit.repos.createDispatchEvent({
+        owner,
+        repo: repoName,
+        event_type: 'stop-server',
+        client_payload: { server: serverName },
+      });
+      console.log(`Stop dispatch for server '${serverName}' sent`);
+      break;
+    case 'status':
+      try {
+        const { data } = await octokit.repos.getContent({
+          owner,
+          repo: repoName,
+          path: `${serverName}/status.txt`,
+        });
+        const content = Buffer.from(data.content, data.encoding).toString('utf8').trim();
+        console.log(content);
+      } catch (err) {
+        console.error('Failed to get status:', err.message);
+        process.exit(1);
+      }
       break;
     default:
       console.error(`Unknown command: ${command}`);


### PR DESCRIPTION
## Summary
- extend `elder` CLI to support `start`, `stop`, and `status` commands with repository/token options
- document CLI usage in the README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b39b3ae804832e8cc0c8199160e164